### PR TITLE
Find a forked repository in GitHub search

### DIFF
--- a/cmd/github/github.go
+++ b/cmd/github/github.go
@@ -17,6 +17,10 @@ const QUERY_SEPARATOR = " "
 const SEARCH_REPOS_PER_ONCE = 20
 const TOKEN_NAME = "GITHUB_TOKEN"
 
+// To find forked repositories by search
+// https://docs.github.com/en/search-github/searching-on-github/searching-in-forks
+const FORK_QUERY = "fork:true"
+
 type GitHubRepository struct {
 	Name            string
 	Owner           string
@@ -156,7 +160,7 @@ func FetchFromGitHub(params []FetchRepositoryParam) []GitHubRepository {
 	for i, param := range params {
 		names[i] = param.QueryWord()
 	}
-	q := strings.Join(names, QUERY_SEPARATOR)
+	q := strings.Join(names, QUERY_SEPARATOR) + " " + FORK_QUERY
 	variables := map[string]interface{}{
 		"query": githubv4.String(q),
 		"count": githubv4.Int(len(names)),


### PR DESCRIPTION
Thank you for a great tool!

# Problem to be solved
`rails/web-console` is currently not detectable by dep-doctor.

```
[warn] web-console (unknown):
```

This is because the GraphQL Query cannot discover what has been forked.
Here are the results in [Explorer](https://docs.github.com/en/graphql/overview/explorer).

request:

```
query {
  search(query: "repo:rails/web-console", type: REPOSITORY, first: 10) {
    edges {
      node {
        ... on Repository {
          isArchived
          nameWithOwner
          isMirror
          url
          owner {
            login
          }
          defaultBranchRef{
            target{
              ... on Commit {
               history(first: 1) {
                edges{
                  node{
                    committedDate
                  }
                }
              } 
              }
            }
          }
        }
      }
    }
  }
}
```

response

```
{
  "data": {
    "search": {
      "edges": []
    }
  }
}
```

with `fork:true` , we can get the result as expected.

```
query {
  search(query: "repo:rails/web-console fork:true", type: REPOSITORY, first: 10) {
    edges {
      node {
        ... on Repository {
          isArchived
          nameWithOwner
          isMirror
          url
          owner {
            login
          }
          defaultBranchRef{
            target{
              ... on Commit {
               history(first: 1) {
                edges{
                  node{
                    committedDate
                  }
                }
              } 
              }
            }
          }
        }
      }
    }
  }
}
```

result

```
{
  "data": {
    "search": {
      "edges": [
        {
          "node": {
            "isArchived": false,
            "nameWithOwner": "rails/web-console",
            "isMirror": false,
            "url": "https://github.com/rails/web-console",
            "owner": {
              "login": "rails"
            },
            "defaultBranchRef": {
              "target": {
                "history": {
                  "edges": [
                    {
                      "node": {
                        "committedDate": "2023-12-08T18:04:17Z"
                      }
                    }
                  ]
                }
              }
            }
          }
        }
      ]
    }
  }
}
```

I built `dep-doctor` with this change, `rails/web-console` is diagnosed expectedly.

Could you review? and let me run the CI 🙏 

Thanks!